### PR TITLE
Refactor FilterOptions

### DIFF
--- a/crates/bloom/src/atoms.rs
+++ b/crates/bloom/src/atoms.rs
@@ -6,5 +6,13 @@ rustler::atoms! {
     undefined,
     binencode,
     bindecode,
-    wrong_filter_type
+    wrong_filter_type,
+    bitmap_size,
+    bloom,
+    capacity,
+    fbf,
+    filter_type,
+    fp_rate,
+    items_count,
+    rotate_at,
 }

--- a/crates/bloom/src/filter/mod.rs
+++ b/crates/bloom/src/filter/mod.rs
@@ -3,7 +3,10 @@ mod forgetful;
 
 pub use self::{bloom::BloomFilter, forgetful::ForgetfulFilter};
 use crate::{container::SerializedFilter, options::FilterOptions};
+use rustler::{Atom, Decoder, Encoder, Env, Error, NifResult, Term};
 use serde::{Deserialize, Serialize};
+
+type Result<T> = std::result::Result<T, String>;
 
 pub enum Filter {
     Bloom(BloomFilter),
@@ -11,11 +14,11 @@ pub enum Filter {
 }
 
 impl Filter {
-    pub fn new(opts: FilterOptions) -> Self {
-        match opts.filter_type {
-            FilterType::Forgetful => Filter::Forgetful(ForgetfulFilter::new(opts)),
-            FilterType::Bloom => Filter::Bloom(BloomFilter::new(opts)),
-        }
+    pub fn new(opts: FilterOptions) -> Result<Self> {
+        Ok(match opts.filter_type.ok_or("`filter_type` not set")? {
+            FilterType::Forgetful => Filter::Forgetful(ForgetfulFilter::new(opts)?),
+            FilterType::Bloom => Filter::Bloom(BloomFilter::new(opts)?),
+        })
     }
 
     pub fn filter_type(&self) -> FilterType {
@@ -25,18 +28,24 @@ impl Filter {
         }
     }
 
-    pub fn serialize(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    pub fn serialize(&self) -> Result<Vec<u8>> {
         match self {
             Self::Bloom(filt) => filt.serialize(),
             Self::Forgetful(filt) => filt.serialize(),
         }
     }
 
-    pub fn restore(prev_filter: SerializedFilter) -> Self {
-        match prev_filter.opts.filter_type {
-            FilterType::Bloom => Self::Bloom(BloomFilter::restore(prev_filter)),
-            FilterType::Forgetful => Self::Forgetful(ForgetfulFilter::restore(prev_filter)),
-        }
+    pub fn restore(prev_filter: SerializedFilter) -> Result<Self> {
+        Ok(
+            match prev_filter
+                .opts
+                .filter_type
+                .ok_or("`filter_type` not set")?
+            {
+                FilterType::Bloom => Self::Bloom(BloomFilter::restore(prev_filter)),
+                FilterType::Forgetful => Self::Forgetful(ForgetfulFilter::restore(prev_filter)),
+            },
+        )
     }
 
     pub fn clear(&mut self) {
@@ -54,8 +63,32 @@ impl Filter {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub enum FilterType {
     Bloom,
     Forgetful,
+}
+
+impl<'a> Decoder<'a> for FilterType {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        use crate::atoms;
+        let ft = Atom::from_term(term)?;
+        if ft == atoms::bloom() {
+            Ok(Self::Bloom)
+        } else if ft == atoms::fbf() {
+            Ok(Self::Forgetful)
+        } else {
+            Err(Error::RaiseTerm(Box::new(atoms::wrong_filter_type())))
+        }
+    }
+}
+
+impl Encoder for FilterType {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match self {
+            Self::Bloom => crate::atoms::bloom(),
+            Self::Forgetful => crate::atoms::fbf(),
+        }
+        .encode(env)
+    }
 }

--- a/crates/bloom/src/options.rs
+++ b/crates/bloom/src/options.rs
@@ -1,25 +1,45 @@
-use serde::{Deserialize, Serialize};
 use filter::FilterType;
+use rustler::{Decoder, NifResult, Term};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Copy, Debug)]
 pub struct FilterOptions {
-    pub filter_type: FilterType,
-    pub bitmap_size: usize,
-    pub items_count: usize,
-    pub capacity: usize,
-    pub rotate_at: usize,
-    pub fp_rate: f64,
+    pub filter_type: Option<FilterType>,
+    pub bitmap_size: Option<usize>,
+    pub items_count: Option<usize>,
+    pub capacity: Option<usize>,
+    pub rotate_at: Option<usize>,
+    pub fp_rate: Option<f64>,
 }
 
 impl Default for FilterOptions {
     fn default() -> FilterOptions {
         FilterOptions {
-            filter_type: FilterType::Bloom,
-            bitmap_size: 10,
-            items_count: 100,
-            capacity: 3,
-            rotate_at: 0,
-            fp_rate: 0.1,
+            filter_type: None,
+            bitmap_size: None,
+            items_count: None,
+            capacity: None,
+            rotate_at: None,
+            fp_rate: None,
         }
+    }
+}
+
+impl<'a> Decoder<'a> for FilterOptions {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let mut opts = Self::default();
+        use rustler::{Error, MapIterator};
+        for (key, value) in MapIterator::new(term).ok_or(Error::BadArg)? {
+            match key.atom_to_string()?.as_ref() {
+                "filter_type" => opts.filter_type = Some(value.decode()?),
+                "bitmap_size" => opts.bitmap_size = Some(value.decode()?),
+                "items_count" => opts.items_count = Some(value.decode()?),
+                "capacity" => opts.capacity = Some(value.decode()?),
+                "rotate_at" => opts.rotate_at = Some(value.decode()?),
+                "fp_rate" => opts.fp_rate = Some(value.decode()?),
+                _ => (),
+            }
+        }
+        Ok(opts)
     }
 }


### PR DESCRIPTION
`FilterOptions` currently implements `Default` with what appears like reasonable defaults, but this causes a non-obvious bug. The bug stems from the fact that these defaults interfere with filter constructor dispatching.

As an example, the defaults for `bitmap_size` and `items_count` are `10` and `100`, respectively. The decision to call `Bloom::new` instead of `Bloom::new_for_fp_rate()` looks like this:

```rust
            if opts.items_count > 0 && opts.bitmap_size == 0 {
                Bloom::new_for_fp_rate(opts.items_count as usize, opts.fp_rate)
            } else {
                Bloom::new(opts.bitmap_size, opts.items_count)
            },
```

Because the first `if` clause is always false, only `Bloom::new()` will be called, regardless of whether the user calls `bloom:new/2` or `bloom:new_optimal/2` in Erlang.
