### PR TITLE
Allow for cross-compilation via external `RUSTFLAGS`

### DIFF
--- a/crates/bloom/.gitignore
+++ b/crates/bloom/.gitignore
@@ -1,2 +1,3 @@
 target/*
 .idea/*
+libpath

--- a/crates/bloom/Cargo.toml
+++ b/crates/bloom/Cargo.toml
@@ -3,6 +3,7 @@ name = "bloom"
 version = "0.2.0"
 authors = ["Maxim Molchanov <m.molchanov@vonmo.com>"]
 license = "MIT/Apache-2.0"
+build = "build.rs"
 
 [lib]
 name = "bloom"

--- a/crates/bloom/build.rs
+++ b/crates/bloom/build.rs
@@ -1,0 +1,31 @@
+use std::{env, fs::File, io::Write, path::Path};
+
+fn main() {
+    // Directory contain this build-script
+    let here = env::var("CARGO_MANIFEST_DIR").unwrap();
+    // Host triple (arch of machine doing to build, not necessarily the arch we're building for)
+    let host_triple = env::var("HOST").unwrap();
+    // Target triple (arch we're building for, not necessarily the arch we're building on)
+    let target_triple = env::var("TARGET").unwrap();
+    // debug or release
+    let profile = env::var("PROFILE").unwrap();
+    // We use target OS to determine if extension is `.so`, `.dll`, or `.dylib`
+    let file_name = match env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
+        "windows" => "libbloom.dll",
+        "macos" | "ios" => "libbloom.dylib",
+        _ => "libbloom.so",
+    };
+
+    // Location of libbloom
+    let mut libpath = Path::new(&here).join("target");
+    if host_triple != target_triple {
+        libpath = libpath.join(&target_triple);
+    }
+    libpath = libpath.join(&profile).join(&file_name);
+
+    // Create file in `here` and write the path to the directory of
+    // where to find libbloom
+    let libpath_file_path = Path::new(&here).join("libpath");
+    let mut libpath_file = File::create(libpath_file_path).unwrap();
+    write!(libpath_file, "{}", libpath.to_str().unwrap()).unwrap();
+}

--- a/rebar.config
+++ b/rebar.config
@@ -57,8 +57,8 @@
 {erl_opts, [no_debug_info, warnings_as_errors]}.
 {relx, [{dev_mode, false}, {include_erts, true}, {include_src, false}]}.
 {pre_hooks, [
-  {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/bloom && cargo build --release && cp target/release/libbloom.so ../../priv/\""},
-  {"(darwin)", compile, "sh -c \"cd crates/bloom && cargo build --release && cp target/release/libbloom.dylib ../../priv/libbloom.so\""}
+  {compile, "cargo build --manifest-path=crates/bloom/Cargo.toml --release"},
+  {compile, "sh -c \"cp $(cat crates/bloom/libpath) priv/libbloom.so\""}
 ]}.
 
 {profiles, [
@@ -66,8 +66,8 @@
         {erl_opts, [no_debug_info, warnings_as_errors]},
         {relx, [{dev_mode, false}, {include_erts, true}, {include_src, false}]},
         {pre_hooks, [
-          {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/bloom && cargo build --release && cp target/release/libbloom.so ../../priv/\""},
-          {"(darwin)", compile, "sh -c \"cd crates/bloom && cargo build --release && cp target/release/libbloom.dylib ../../priv/libbloom.so\""}
+          {compile, "cargo build --manifest-path=crates/bloom/Cargo.toml --release"},
+          {compile, "sh -c \"cp $(cat crates/bloom/libpath) priv/libbloom.so\""}
         ]}
     ]},
 
@@ -79,8 +79,8 @@
         {erl_opts, [debug_info, warnings_as_errors, nowarn_export_all]},
         {relx, [{dev_mode, true}, {include_erts, false}, {include_src, false}]},
         {pre_hooks, [
-          {"(linux|solaris|freebsd)", compile, "sh -c \"cd crates/bloom && cargo build && cp target/debug/libbloom.so ../../priv/\""},
-          {"(darwin)", compile, "sh -c \"cd crates/bloom && cargo build && cp target/debug/libbloom.dylib ../../priv/libbloom.so\""}
+          {compile, "cargo build --manifest-path=crates/bloom/Cargo.toml --release"},
+          {compile, "sh -c \"cp $(cat crates/bloom/libpath) priv/libbloom.so\""}
         ]}
     ]},
 


### PR DESCRIPTION
When cross-compiling this NIF, the path to the built Rust library is different than the typical `target/release/libname.so`. There are no stable mechanisms to dictate to cargo where to output the library, but we can infer its location in a build script. The solution is to write the library's path to a file and use that file's contents as the source parameter when installing the lib.

The result of running the new `build.rs` build-script is the file `crates/bloom/libpath`. Its contents is path to our `libbloom.[so,dylib,dll]`, accountanting differing build paths duet to cross-compiling, target OS, build/debug.
